### PR TITLE
Add .my extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
                     "mib"
                 ],
                 "extensions": [
-                    ".mib"
+                    ".mib",
+                    ".my"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
It would also be nice if the language was detected for `.txt` files having MIB specific content like `DEFINITIONS ::= BEGIN` for example..